### PR TITLE
README: API docs links repaired

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ signatures the MirageOS key/value devices should implement.
 
 mirage-kv is distributed under the ISC license.
 
-[ro]: https://mirage.github.io/mirage-kv/Mirage_kv.html
-[ro-lwt]: https://mirage.github.io/mirage-kv/Mirage_kv_lwt.html
+[ro]: http://docs.mirage.io/mirage-kv/Mirage_kv/module-type-RO/index.html
+[ro-lwt]: http://docs.mirage.io/mirage-kv-lwt/Mirage_kv_lwt/module-type-RO/index.html
 
 ## Installation
 
@@ -23,4 +23,4 @@ The documentation and API reference is generated from the source
 interfaces. It can be consulted [online][doc] or via `odig doc
 mirage-kv`.
 
-[doc]: https://mirage.github.io/mirage-kv/
+[doc]: http://docs.mirage.io/mirage-kv/

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ signatures the MirageOS key/value devices should implement.
 
 mirage-kv is distributed under the ISC license.
 
-[ro]: http://docs.mirage.io/mirage-kv/Mirage_kv/module-type-RO/index.html
-[ro-lwt]: http://docs.mirage.io/mirage-kv-lwt/Mirage_kv_lwt/module-type-RO/index.html
+[ro]: https://mirage.github.io/mirage-kv/mirage-kv/Mirage_kv/module-type-RO/index.html
+[ro-lwt]: https://mirage.github.io/mirage-kv/mirage-kv-lwt/Mirage_kv_lwt/index.html#module-type-RO
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ instructions.
 ## Documentation
 
 The documentation and API reference is generated from the source
-interfaces. It can be consulted [online][doc] or via `odig doc
-mirage-kv`.
+interfaces. API docs for both [mirage-kv][doc-mirage-kv] and
+[mirage-kv-lwt][doc-mirage-kv-lwt] can be consulted online or via `odig
+doc mirage-kv`.
 
-[doc]: http://docs.mirage.io/mirage-kv/
+[doc-mirage-kv]: http://docs.mirage.io/mirage-kv/
+[doc-mirage-kv-lwt]: http://docs.mirage.io/mirage-kv-lwt/


### PR DESCRIPTION
This PR amends API documentation links in the README.

Fixes #9 

It seems that there's no `index.html` generated for the "starting page" of this library, but the linked API docs pages exist. This PR changes the "general API docs link" to the one at mirage.io.