### PR TITLE
revise read API: take length and offset as optional named arguments, …

### DIFF
--- a/lwt/mirage_kv_lwt.ml
+++ b/lwt/mirage_kv_lwt.ml
@@ -1,4 +1,5 @@
 (*
+ * Copyright (c) 2018      Stefanie Schirmer, Hannes Mehnert
  * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
  * Copyright (c) 2013      Citrix Systems Inc
@@ -22,4 +23,4 @@
 
 module type RO = Mirage_kv.RO
   with type 'a io = 'a Lwt.t
-   and type page_aligned_buffer = Cstruct.t
+   and type buffer = Cstruct.t

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -1,4 +1,5 @@
 (*
+ * Copyright (c) 2018      Stefanie Schirmer, Hannes Mehnert
  * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
  * Copyright (c) 2013      Citrix Systems Inc
@@ -25,9 +26,9 @@ module type RO = sig
   type error = private [> `Unknown_key of string]
   val pp_error: error Fmt.t
   include Mirage_device.S
-  type page_aligned_buffer
-  val read: t -> string -> int64 -> int64 ->
-    (page_aligned_buffer list, error) result io
+  type buffer
+  val read: t -> string -> ?offset:int64 -> ?length:int64 ->
+    (buffer, error) result io
   val mem: t -> string -> (bool, error) result io
   val size: t -> string -> (int64, error) result io
 end

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -1,4 +1,5 @@
 (*
+ * Copyright (c) 2018      Stefanie Schirmer, Hannes Mehnert
  * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
  * Copyright (c) 2013      Citrix Systems Inc
@@ -38,14 +39,15 @@ module type RO = sig
 
   include Mirage_device.S
 
-  type page_aligned_buffer
-  (** The type for memory buffers.*)
+  type buffer
+  (** The type for memory buffer.*)
 
-  val read: t -> string -> int64 -> int64 ->
-    (page_aligned_buffer list, error) result io
-  (** [read t key offset length] reads up to [length] bytes from the
-      value associated with [key]. If less data is returned than
-      requested, this indicates the end of the value. *)
+  val read: t -> string -> ?offset:int64 -> ?length:int64 ->
+    (buffer, error) result io
+  (** [read t key ~offset ~length] reads up to [length] bytes from the value
+      associated with [key] starting at [offset] (defaults to 0).  If [length]
+      is not given, the end of value is used.  If [offset + length] is longer
+      than the [value], we return what we can. *)
 
   val mem: t -> string -> (bool, error) result io
   (** [mem t key] returns [true] if a value is set for [key] in [t],

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -50,10 +50,9 @@ module type RO = sig
       than the [value], we return what we can. *)
 
   val mem: t -> string -> (bool, error) result io
-  (** [mem t key] returns [true] if a value is set for [key] in [t],
-      and [false] if not so. *)
+  (** [mem t key] returns whether a value is set for [key] in [t]. *)
 
   val size: t -> string -> (int64, error) result io
-  (** Get the value size. *)
+  (** [size t key] returns the size of the value [key] in [t]. *)
 
 end


### PR DESCRIPTION
…return single buffer instead of list

rename page_aligned_buffer to buffer to be consistent with mirage-flow API

(joint work with @linse) see earlier discussion in https://github.com/mirage/mirage-fs/issues/20