### PR TITLE
New RO and RW signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
   global:
   - PINS="mirage-kv.dev:. mirage-kv-lwt.dev:."
   matrix:
-  - OCAML_VERSION=4.03 PACKAGE="mirage-kv-lwt"
-  - OCAML_VERSION=4.04 PACKAGE="mirage-kv-lwt"
   - OCAML_VERSION=4.05 PACKAGE="mirage-kv-lwt"
+  - OCAML_VERSION=4.06 PACKAGE="mirage-kv-lwt"
+  - OCAML_VERSION=4.07 PACKAGE="mirage-kv-lwt"

--- a/lwt/mirage_kv_lwt.ml
+++ b/lwt/mirage_kv_lwt.ml
@@ -22,4 +22,8 @@
 
 module type RO = Mirage_kv.RO
   with type 'a io = 'a Lwt.t
-   and type page_aligned_buffer = Cstruct.t
+   and type buffer = string
+
+module type RW = Mirage_kv.RW
+  with type 'a io = 'a Lwt.t
+   and type buffer = string

--- a/lwt/mirage_kv_lwt.ml
+++ b/lwt/mirage_kv_lwt.ml
@@ -22,8 +22,8 @@
 
 module type RO = Mirage_kv.RO
   with type 'a io = 'a Lwt.t
-   and type buffer = string
+   and type value = string
 
 module type RW = Mirage_kv.RW
   with type 'a io = 'a Lwt.t
-   and type buffer = string
+   and type value = string

--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -18,6 +18,7 @@ depends: [
   "dune"     {build}
   "mirage-device" {>= "1.0.0"}
   "fmt"
+  "alcotest" {test}
 ]
 
 synopsis: "MirageOS signatures for key/value devices"

--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -16,11 +16,10 @@ build-test: [
   ["dune" "runtest" "-p" name]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.05.0"}
   "dune"     {build}
   "mirage-device" {>= "1.0.0"}
   "fmt"
   "alcotest" {test}
 ]
-
 synopsis: "MirageOS signatures for key/value devices"

--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -12,7 +12,9 @@ build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-
+build-test: [
+  ["dune" "runtest" "-p" name]
+]
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"     {build}

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -78,4 +78,5 @@ module type RW = sig
   val pp_write_error: write_error Fmt.t
   val set: t -> key -> value -> (unit, write_error) result io
   val remove: t -> key -> (unit, write_error) result io
+  val batch: t -> (t -> 'a) -> 'a
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -71,7 +71,7 @@ module type RO = sig
   val digest: t -> key -> (string, error) result io
 end
 
-type write_error = [ error | `No_space ]
+type write_error = [ error | `No_space | `Too_many_retries ]
 
 module type RW = sig
   include RO
@@ -79,5 +79,5 @@ module type RW = sig
   val pp_write_error: write_error Fmt.t
   val set: t -> key -> value -> (unit, write_error) result io
   val remove: t -> key -> (unit, write_error) result io
-  val batch: t -> (t -> 'a) -> 'a
+  val batch: t -> ?retries:int -> (t -> 'a) -> 'a
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -16,17 +16,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type error = [
-  | `Not_found           of string
-  | `Dictionary_expected of string
-  | `Value_expected      of string
-]
-
-let pp_error ppf = function
-  | `Not_found k           -> Fmt.pf ppf "Cannot find the key %s" k
-  | `Dictionary_expected k -> Fmt.pf ppf "Expecting a dictionary for the key %s" k
-  | `Value_expected k      -> Fmt.pf ppf "Expecting a value for the key %s" k
-
 module Key = struct
 
   type t = string list
@@ -49,6 +38,19 @@ module Key = struct
 end
 
 type key = Key.t
+
+type error = [
+  | `Not_found           of key
+  | `Dictionary_expected of key
+  | `Value_expected      of key
+]
+
+let pp_error ppf = function
+  | `Not_found k           -> Fmt.pf ppf "Cannot find the key %a" Key.pp k
+  | `Dictionary_expected k ->
+    Fmt.pf ppf "Expecting a dictionary for the key %a" Key.pp k
+  | `Value_expected k      ->
+    Fmt.pf ppf "Expecting a value for the key %a" Key.pp k
 
 module type RO = sig
   type nonrec error = private [> error]

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -71,7 +71,13 @@ module type RO = sig
   val digest: t -> key -> (string, error) result io
 end
 
-type write_error = [ error | `No_space | `Too_many_retries ]
+type write_error = [ error | `No_space | `Too_many_retries of int ]
+
+let pp_write_error ppf = function
+  | #error as e -> pp_error ppf e
+  | `No_space   -> Fmt.pf ppf "No space left on device"
+  | `Too_many_retries n ->
+    Fmt.pf ppf "Aborting after %d attempts to apply the batch operations." n
 
 module type RW = sig
   include RO

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -85,5 +85,5 @@ module type RW = sig
   val pp_write_error: write_error Fmt.t
   val set: t -> key -> value -> (unit, write_error) result io
   val remove: t -> key -> (unit, write_error) result io
-  val batch: t -> ?retries:int -> (t -> 'a) -> 'a
+  val batch: t -> ?retries:int -> (t -> 'a io) -> 'a io
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -16,18 +16,82 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type error = [`Unknown_key of string]
+type error = [
+  | `Not_found  of string
+  | `Is_a_tree  of string
+  | `Not_a_tree of string
+]
 
 let pp_error ppf = function
-  | `Unknown_key k -> Fmt.pf ppf "key %s not present in the store" k
+  | `Not_found k  -> Fmt.pf ppf "Cannot find %s" k
+  | `Is_a_tree k  -> Fmt.pf ppf "%s is a tree" k
+  | `Not_a_tree k -> Fmt.pf ppf "%s is not a tree" k
+
+module Path = struct
+
+  type t = string list
+  (* Store the path as a reverse list to optimise basename and (/)
+     operations *)
+
+  let v s = List.rev (String.split_on_char '/' s)
+  let add_seg t v = v :: t
+  let ( / ) = add_seg
+  let append x y = y @ x
+  let ( // ) = append
+  let segs = List.rev
+  let basename = List.hd
+  let parent = List.tl
+  let compare = compare
+  let equal = (=)
+  let pp ppf l = Fmt.(list ~sep:(unit "/") string) ppf (List.rev l)
+  let to_string = Fmt.to_to_string pp
+
+  let get_ext = function
+    | []   -> ""
+    | h::_ -> Filename.extension h
+
+  let has_ext e = function
+    | []   -> false
+    | h::_ -> e = Filename.extension h
+
+  let add_ext e = function
+    | []   -> []
+    | h::t -> (h ^ "." ^ e) :: t
+
+  let rem_ext = function
+    | []   -> []
+    | h::t -> Filename.remove_extension h :: t
+
+  let set_ext e t = add_ext e (rem_ext t)
+
+  let ( + ) t e = add_ext e t
+
+end
+
+type path = Path.t
 
 module type RO = sig
-  type error = private [> `Unknown_key of string]
+  type nonrec error = private [> error]
   val pp_error: error Fmt.t
   include Mirage_device.S
-  type page_aligned_buffer
-  val read: t -> string -> int64 -> int64 ->
-    (page_aligned_buffer list, error) result io
-  val mem: t -> string -> (bool, error) result io
-  val size: t -> string -> (int64, error) result io
+  type buffer
+  val mem: t -> path -> (bool, error) result io
+  val mem_tree: t -> path -> bool io
+  val get: t -> ?off:int64 -> ?len:int64 -> path -> (buffer, error) result io
+  val kind: t -> path -> [`Buffer | `Tree] option io
+  val list: t -> path -> (string * [`Buffer | `Tree]) list io
+  val size: t -> path -> (int64, error) result io
+  val mtime: t -> path -> (int64, error) result io
+  val digest: t -> path -> (string, error) result io
+end
+
+type write_error = error
+
+module type RW = sig
+  include RO
+  type nonrec write_error = private [> write_error]
+  val pp_write_error: write_error Fmt.t
+  val set: t -> ?off:int64 -> ?len:int64 -> path -> buffer ->
+    (unit, write_error) result io
+  val remove: t -> path -> (unit, write_error) result io
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -22,9 +22,15 @@ module Key = struct
   (* Store the path as a reverse list to optimise basename and (/)
      operations *)
 
+  let err_invalid_segment x = Fmt.failwith "%S is not a valid segment" x
+
+  let check_segment x =
+    String.iter (function '/' -> err_invalid_segment x | _ -> ()) x;
+    x
+
   let empty = []
   let v s = List.filter ((<>)"") @@ List.rev (String.split_on_char '/' s)
-  let add t v = v :: t
+  let add t v = (check_segment v) :: t
   let ( / ) = add
   let append x y = y @ x
   let ( // ) = append

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -55,9 +55,9 @@ module type RO = sig
   val pp_error: error Fmt.t
   include Mirage_device.S
   type value
-  val exists: t -> key -> [`Value | `Dictionary] option io
+  val exists: t -> key -> ([`Value | `Dictionary], error) result io
   val get: t -> key -> (value, error) result io
-  val list: t -> key -> (string * [`Value | `Dictionary]) list io
+  val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result io
   val last_modified: t -> key -> (int * int64, error) result io
   val digest: t -> key -> (string, error) result io
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -62,6 +62,7 @@ module type RO = sig
   type nonrec error = private [> error]
   val pp_error: error Fmt.t
   include Mirage_device.S
+  type key = Key.t
   type value
   val exists: t -> key -> ([`Value | `Dictionary] option, error) result io
   val get: t -> key -> (value, error) result io

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -63,7 +63,7 @@ module type RO = sig
   val pp_error: error Fmt.t
   include Mirage_device.S
   type value
-  val exists: t -> key -> ([`Value | `Dictionary], error) result io
+  val exists: t -> key -> ([`Value | `Dictionary] option, error) result io
   val get: t -> key -> (value, error) result io
   val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result io
   val last_modified: t -> key -> (int * int64, error) result io

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -205,7 +205,7 @@ module type RW = sig
      enclosing {!batch} operation, where durability will be guaranteed
      at the end of the batch. *)
 
-  val batch: t -> ?retries:int -> (t -> 'a) -> 'a
+  val batch: t -> ?retries:int -> (t -> 'a io) -> 'a io
   (** [batch t f] run [f] in batch. Ensure the durability of
      operations.
 

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -113,10 +113,15 @@ module type RO = sig
   type value
   (** The type for values. *)
 
- val exists: t -> key -> ([`Value | `Dictionary], error) result io
+ val exists: t -> key -> ([`Value | `Dictionary] option, error) result io
  (** [exists t k] is [Some `Value] if [k] is bound to a value in [t],
     [Some `Dictionary] if [k] is a prefix of a valid key in [t] and
-    [None] if no key with that prefix exists in [t]. *)
+    [None] if no key with that prefix exists in [t].
+
+     {!exists} answers two questions: does the key exist and is it
+    referring to a value or a dictionary.
+
+     An error occurs when the underlying storage layer fails. *)
 
  val get: t -> key -> (value, error) result io
  (** [get t k] is the value bound to [k] in [t]. *)

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -110,6 +110,9 @@ module type RO = sig
 
   include Mirage_device.S
 
+  type key = Key.t
+  (** The type for keys. *)
+
   type value
   (** The type for values. *)
 

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -163,9 +163,13 @@ end
 
 type write_error = [
   | error
-  | `No_space         (** No space left on the device. *)
-  | `Too_many_retries (** {!batch} commit failed with too many retries. *)
+  | `No_space                (** No space left on the device. *)
+  | `Too_many_retries of int (** {!batch} has been trying to commit [n] times
+                                 without success. *)
 ]
+
+val pp_write_error: write_error Fmt.t
+(** [pp_write_error] is the pretty-printer for write errors. *)
 
 module type RW = sig
 

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -22,15 +22,91 @@
 
 (** {1 Mirage_kv} *)
 
-type error = [`Unknown_key of string]
+type error = [
+  | `Not_found  of string
+  | `Is_a_tree  of string
+  | `Not_a_tree of string
+]
 (** The type for errors. *)
 
 val pp_error: error Fmt.t
 (** [pp_error] is the pretty-printer for errors. *)
 
+module Path: sig
+
+  type t
+  (** The type for paths. *)
+
+  val v : string -> t
+  (** [v s] is the string [s] as a path. *)
+
+  val add_seg : t -> string -> t
+  (** [add_seg t s] is the path [t/s] *)
+
+  val ( / ) : t -> string -> t
+  (** [t / x] is [add_seg t x]. *)
+
+  val append : t -> t -> t
+  (** [append x y] is the path [x / y]. *)
+
+  val ( // ) : t -> t -> t
+  (** [x // y] is [append x y]. *)
+
+  val segs : t-> string list
+  (** [segs t] is [t]'s list of segments. *)
+
+  val basename : t -> string
+  (** [basename t] is the last non-empty segment of [t]. *)
+
+  val parent : t -> t
+  (** [parent t] is a directory path that contains [t]. *)
+
+  val compare : t-> t -> int
+  (** The comparison function for paths. *)
+
+  val equal : t -> t -> bool
+  (** The equality function for paths. *)
+
+  val pp : t Fmt.t
+  (** The pretty printer for paths. *)
+
+  val to_string: t -> string
+  (** [to_string] is [Fmt.to_to_string pp]. *)
+
+  val get_ext : t -> string
+  (** [get_ext t] is [t]'s basename file extension. *)
+
+  val has_ext : string -> t -> bool
+  (** [has_ext e t] is [true] iff [get_ext t = e] *)
+
+  val add_ext : string -> t -> t
+  (** [add_ext e t] is [t] with the string [e] concatenated to [t]'s
+     basename. *)
+
+  val rem_ext : t -> t
+  (** [rem_ext t] is [t] with the extension of [t]'s basename
+     removed. *)
+
+  val set_ext : string -> t -> t
+  (** [set_ext e t] is [add_ext e (rem_ext t)]. *)
+
+  val ( + ) : t -> string -> t
+  (** [t + e] is [add_ext e t]. *)
+
+end
+
+type path = Path.t
+(** The type for store paths. *)
+
 module type RO = sig
 
-  type error = private [> `Unknown_key of string]
+  (** {1 Read-only, key-value stores} *)
+
+  (** MirageOS read-only key-value stores are read-only tree-like structures
+      holding buffers on their leaves. The functions in [RO] allow to distinguish
+      between intermediate and leafs nodes. *)
+
+  type nonrec error = private [> error]
   (** The type for errors. *)
 
   val pp_error: error Fmt.t
@@ -38,20 +114,61 @@ module type RO = sig
 
   include Mirage_device.S
 
-  type page_aligned_buffer
+  type buffer
   (** The type for memory buffers.*)
 
-  val read: t -> string -> int64 -> int64 ->
-    (page_aligned_buffer list, error) result io
-  (** [read t key offset length] reads up to [length] bytes from the
-      value associated with [key]. If less data is returned than
-      requested, this indicates the end of the value. *)
+  val mem: t -> path -> (bool, error) result io
+  (** [mem t p] is [true] iff a buffer is bound t [p] in [t]. *)
 
-  val mem: t -> string -> (bool, error) result io
-  (** [mem t key] returns [true] if a value is set for [key] in [t],
-      and [false] if not so. *)
+  val mem_tree: t -> path -> bool io
+  (** [mem_tree t p] is [true] iff there exists a tree bound the path
+     [p]. This means there exists a buffer bound to a path [p'] in
+     [t], such that [p'] is a prefix of [p]. *)
 
-  val size: t -> string -> (int64, error) result io
-  (** Get the value size. *)
+ val get: t -> ?off:int64 -> ?len:int64 -> path -> (buffer, error) result io
+  (** [get t ?off ?len p] is a view of the buffer bound to [p] in [t].
+     By default, [off] is 0 and [len] is the length of the buffer less
+     [off]. *)
+
+ val kind: t -> path -> [`Buffer | `Tree] option io
+  (** [kind t p] is [Some `Buffer] if [p] is bound to a buffer in [t],
+     [Some `Tree] if [p] is a prefix of the valid key in [t] and
+     [None] if no key with that prefix exists in [t]. *)
+
+  val list: t -> path -> (string * [`Buffer | `Tree]) list io
+  (** [list t p] is the list of entries (with their kind) in the tree
+     bound to [p]. *)
+
+  val size: t -> path -> (int64, error) result io
+  (** [size t p] is the size of the buffer bound to [p] in [t]. *)
+
+  val mtime: t -> path -> (int64, error) result io
+  (** [mtime t p] is the last time the value bound to [p] in [t] has
+     been modified. *)
+
+  val digest: t -> path -> (string, error) result io
+  (** [digest t p] is the digest of the value bound to [p] int [t]. *)
+
+end
+
+type write_error = error
+
+module type RW = sig
+
+  include RO
+
+  type nonrec write_error = private [> write_error]
+  (** The type for write errors. *)
+
+  val pp_write_error: write_error Fmt.t
+  (** The pretty-printer for [pp_write_error]. *)
+
+  val set: t ->  ?off:int64 -> ?len:int64 -> path -> buffer ->
+    (unit, write_error) result io
+  (** [set t p v] adds the binding [p -> v] to [t]. *)
+
+  val remove: t -> path -> (unit, write_error) result io
+  (** [remove t p] remove binding to [p] in [t]. If [p] was bound to a
+     tree, the full tree will be removed. *)
 
 end

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -25,16 +25,6 @@
 (** MirageOS key-value stores are nested dictionaries, associating
    structured {{!Key}keys} to either dictionaries or values. *)
 
-type error = [
-  | `Not_found           of string (** key not found *)
-  | `Dictionary_expected of string (** key does not refer to a dictionary. *)
-  | `Value_expected      of string (** key does not refer to a value. *)
-]
-(** The type for errors. *)
-
-val pp_error: error Fmt.t
-(** [pp_error] is the pretty-printer for errors. *)
-
 module Key: sig
 
   (** {1 Structured keys} *)
@@ -97,6 +87,16 @@ end
 
 type key = Key.t
 (** The type for keys. *)
+
+type error = [
+  | `Not_found           of key (** key not found *)
+  | `Dictionary_expected of key (** key does not refer to a dictionary. *)
+  | `Value_expected      of key (** key does not refer to a value. *)
+]
+(** The type for errors. *)
+
+val pp_error: error Fmt.t
+(** [pp_error] is the pretty-printer for errors. *)
 
 module type RO = sig
 

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -150,7 +150,7 @@ module type RO = sig
 
       When the value bound to [k] is a dictionary, the modification
      time is the latest modification of all entries in that
-     dictionary.  *)
+     dictionary. This behaviour is only one level deep and not recursive. *)
 
   val digest: t -> key -> (string, error) result io
   (** [digest t k] is the unique digest of the value bound to [k] in

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -113,7 +113,7 @@ module type RO = sig
   type value
   (** The type for values. *)
 
- val exists: t -> key -> [`Value | `Dictionary] option io
+ val exists: t -> key -> ([`Value | `Dictionary], error) result io
  (** [exists t k] is [Some `Value] if [k] is bound to a value in [t],
     [Some `Dictionary] if [k] is a prefix of a valid key in [t] and
     [None] if no key with that prefix exists in [t]. *)
@@ -121,7 +121,7 @@ module type RO = sig
  val get: t -> key -> (value, error) result io
  (** [get t k] is the value bound to [k] in [t]. *)
 
-  val list: t -> key -> (string * [`Value | `Dictionary]) list io
+  val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result io
   (** [list t k] is the list of entries and their types in the
      dictionary referenced by [k] in [t]. *)
 

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(test
+  (name      test)
+  (package   mirage-kv)
+  (libraries mirage-kv alcotest))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,43 @@
+open Mirage_kv
+
+let path = Alcotest.testable Path.pp Path.equal
+
+let path_v () =
+  let check s =  Alcotest.(check string) s s Path.(to_string @@ v s) in
+  check "/foo/bar";
+  check "/foo";
+  check "/";
+  check "foo/bar";
+  check ""
+
+let path_add_seg () =
+  let check t e =
+    let f = t ^ "/" ^ e in
+    let vt = Path.v t in
+    Alcotest.(check string) f f Path.(to_string @@ vt / e);
+    Alcotest.(check path) f vt Path.(parent @@ vt / e);
+    Alcotest.(check string) f e Path.(basename @@ vt / e)
+  in
+  check ""         "bar";
+  check "/"        "foo";
+  check "/foo"     "bar";
+  check "/foo/bar" "toto"
+
+let path_append () =
+  let check x y =
+    let f = x ^ "/" ^ y in
+    let vf = Path.v f in
+    Alcotest.(check path) f vf Path.(v x // v y);
+    Alcotest.(check string) x Path.(basename vf) Path.(basename @@ v y)
+  in
+  check ""         "foo/bar";
+  check "/foo"     "bar";
+  check "/foo/bar" "toto/foox/ko"
+
+let () = Alcotest.run "mirage-kv" [
+    "path", [
+      "Path.v"      , `Quick, path_v;
+      "Path.add_seg", `Quick, path_add_seg;
+      "Path.append" , `Quick, path_append;
+    ]
+  ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -18,10 +18,17 @@ let path_add () =
     Alcotest.(check key)    f vp  Key.(parent @@ vp / b);
     Alcotest.(check string) f b   Key.(basename @@ vp / b)
   in
+  let check_exn p b =
+    try
+      let _ = Key.(v p / b) in
+      Alcotest.failf "%s is not a valid segment, should fail" b
+    with Failure _ -> ()
+  in
   check ""         "bar"  "/bar";
   check "/"        "foo"  "/foo";
   check "/foo"     "bar"  "/foo/bar";
-  check "/foo/bar" "toto" "/foo/bar/toto"
+  check "/foo/bar" "toto" "/foo/bar/toto";
+  check_exn "" "foo/bar"
 
 let path_append () =
   let check x y =

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,43 +1,43 @@
 open Mirage_kv
 
-let path = Alcotest.testable Path.pp Path.equal
+let key = Alcotest.testable Key.pp Key.equal
 
 let path_v () =
-  let check s =  Alcotest.(check string) s s Path.(to_string @@ v s) in
-  check "/foo/bar";
-  check "/foo";
-  check "/";
-  check "foo/bar";
-  check ""
+  let check s e =  Alcotest.(check string) s e Key.(to_string @@ v s) in
+  check "/foo/bar" "/foo/bar";
+  check "/foo"     "/foo";
+  check "/"        "/";
+  check "foo/bar"  "/foo/bar";
+  check ""         "/"
 
-let path_add_seg () =
-  let check t e =
-    let f = t ^ "/" ^ e in
-    let vt = Path.v t in
-    Alcotest.(check string) f f Path.(to_string @@ vt / e);
-    Alcotest.(check path) f vt Path.(parent @@ vt / e);
-    Alcotest.(check string) f e Path.(basename @@ vt / e)
+let path_add () =
+  let check p b exp =
+    let f = p ^ "/" ^ b in
+    let vp = Key.v p in
+    Alcotest.(check string) f exp Key.(to_string @@ vp / b);
+    Alcotest.(check key)    f vp  Key.(parent @@ vp / b);
+    Alcotest.(check string) f b   Key.(basename @@ vp / b)
   in
-  check ""         "bar";
-  check "/"        "foo";
-  check "/foo"     "bar";
-  check "/foo/bar" "toto"
+  check ""         "bar"  "/bar";
+  check "/"        "foo"  "/foo";
+  check "/foo"     "bar"  "/foo/bar";
+  check "/foo/bar" "toto" "/foo/bar/toto"
 
 let path_append () =
   let check x y =
     let f = x ^ "/" ^ y in
-    let vf = Path.v f in
-    Alcotest.(check path) f vf Path.(v x // v y);
-    Alcotest.(check string) x Path.(basename vf) Path.(basename @@ v y)
+    let vf = Key.v f in
+    Alcotest.(check key)    f vf                Key.(v x // v y);
+    Alcotest.(check string) x Key.(basename vf) Key.(basename @@ v y)
   in
-  check ""         "foo/bar";
+  check ""         "/foo/bar";
   check "/foo"     "bar";
-  check "/foo/bar" "toto/foox/ko"
+  check "/foo/bar" "/toto/foox/ko"
 
 let () = Alcotest.run "mirage-kv" [
     "path", [
       "Path.v"      , `Quick, path_v;
-      "Path.add_seg", `Quick, path_add_seg;
+      "Path.add_seg", `Quick, path_add;
       "Path.append" , `Quick, path_append;
     ]
   ]


### PR DESCRIPTION
/cc @linse and @hannesm 

The RO interfaces is a bit more complex now, but I think it's better / simpler to use / more useful. I am a bit undecided about exposing `size`, `mtime` and `digest` in that interface, but why not.

