### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-kv-lwt.opam
+++ b/mirage-kv-lwt.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml"     {>= "4.05.0"}
-  "dune"      {build}
+  "dune"
   "mirage-kv" {>= "2.0.0"}
   "lwt"
   "cstruct"

--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"     {build}
+  "dune"
   "mirage-device" {>= "1.0.0"}
   "fmt"
   "alcotest" {with-test}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.