### PR TITLE
compatibility with older mirage

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
   (name        mirage_kv)
   (public_name mirage-kv)
-  (libraries   fmt mirage-device))
+  (libraries   fmt mirage-device)
+  (wrapped false))

--- a/src/mirage_kv_lwt.ml
+++ b/src/mirage_kv_lwt.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_kv instead."]
+
+include Mirage_kv


### PR DESCRIPTION
this allows a smooth transition path (mirage 3.6.0 --> 3.7.0) with some deprecations.