### PR TITLE
mirage-kv uses Fmt.failwith

### DIFF
--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune"
   "mirage-device" {>= "2.0.0"}
-  "fmt"
+  "fmt" {>= "0.8.4"}
   "lwt" {>= "4.0.0"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
This is only available only since fmt 0.8.4, raise the lower bound.