### PR TITLE
add partial read/write, size and rename

### DIFF
--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -66,7 +66,7 @@ module type RO = sig
   type key = Key.t
   val exists: t -> key -> ([`Value | `Dictionary] option, error) result Lwt.t
   val get: t -> key -> (string, error) result Lwt.t
-  val read: t -> key -> int -> int -> (string, error) result Lwt.t
+  val get_partial: t -> key -> offset:int -> length:int -> (string, error) result Lwt.t
   val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result Lwt.t
   val last_modified: t -> key -> (int * int64, error) result Lwt.t
   val digest: t -> key -> (string, error) result Lwt.t
@@ -86,8 +86,8 @@ module type RW = sig
   type nonrec write_error = private [> write_error]
   val pp_write_error: write_error Fmt.t
   val set: t -> key -> string -> (unit, write_error) result Lwt.t
-  val write: t -> key -> int -> string -> (unit, write_error) result Lwt.t
+  val set_partial: t -> key -> offset:int -> string -> (unit, write_error) result Lwt.t
   val remove: t -> key -> (unit, write_error) result Lwt.t
-  val rename: t -> key -> key -> (unit, write_error) result Lwt.t
+  val rename: t -> source:key -> dest:key -> (unit, write_error) result Lwt.t
   val batch: t -> ?retries:int -> (t -> 'a Lwt.t) -> 'a Lwt.t
 end

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -66,9 +66,11 @@ module type RO = sig
   type key = Key.t
   val exists: t -> key -> ([`Value | `Dictionary] option, error) result Lwt.t
   val get: t -> key -> (string, error) result Lwt.t
+  val read: t -> key -> int -> int -> (string, error) result Lwt.t
   val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result Lwt.t
   val last_modified: t -> key -> (int * int64, error) result Lwt.t
   val digest: t -> key -> (string, error) result Lwt.t
+  val size: t -> key -> (int, error) result Lwt.t
 end
 
 type write_error = [ error | `No_space | `Too_many_retries of int ]
@@ -84,6 +86,8 @@ module type RW = sig
   type nonrec write_error = private [> write_error]
   val pp_write_error: write_error Fmt.t
   val set: t -> key -> string -> (unit, write_error) result Lwt.t
+  val write: t -> key -> int -> string -> (unit, write_error) result Lwt.t
   val remove: t -> key -> (unit, write_error) result Lwt.t
+  val rename: t -> key -> key -> (unit, write_error) result Lwt.t
   val batch: t -> ?retries:int -> (t -> 'a Lwt.t) -> 'a Lwt.t
 end

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -138,6 +138,10 @@ module type RO = sig
   (** [get_partial t k ~offset ~length] is the [length] bytes wide value
      bound at [offset] of [k] in [t].
 
+      If the size of [k] is less than [offset], [get_partial] returns an
+     empty string.
+      If the size of [k] is less than [offset]+[length], [get_partial]
+     returns a short string.
       The result is [Error (`Value_expected k)] if [k] refers to a
      dictionary in [t]. *)
 

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -134,6 +134,13 @@ module type RO = sig
       The result is [Error (`Value_expected k)] if [k] refers to a
       dictionary in [t]. *)
 
+  val read: t -> key -> int -> int -> (string, error) result Lwt.t
+  (** [read t k o l] is the [l] bytes wide value bound at offset [o] of
+     [k] in [t].
+
+      The result is [Error (`Value_expected k)] if [k] refers to a
+     dictionary in [t]. *)
+
   val list: t -> key -> ((string * [`Value | `Dictionary]) list, error) result Lwt.t
   (** [list t k] is the list of entries and their types in the
      dictionary referenced by [k] in [t].
@@ -160,6 +167,10 @@ module type RO = sig
 
       When the value bound to [k] is a dictionary, the digest is a
      unique and deterministic digest of its entries. *)
+
+  val size: t -> key -> (int, error) result Lwt.t
+  (** [size t k] is the size of [k] in [t]. *)
+
 
 end
 
@@ -199,6 +210,13 @@ module type RW = sig
      {!batch} operation, where durability will be guaranteed at the
      end of the batch. *)
 
+  val write: t -> key -> int -> string -> (unit, write_error) result Lwt.t
+  (** [write t k o v] replaces the part of the value bound to [k] in
+     [t] at offset [o] with [v].
+
+      The result is [Error (`Value_expected k)] if [k] refers to a
+     dictionary in [t]. *)
+
   val remove: t -> key -> (unit, write_error) result Lwt.t
   (** [remove t k] removes any binding of [k] in [t]. If [k] was bound
      to a dictionary, the full dictionary will be removed.
@@ -206,6 +224,11 @@ module type RW = sig
       Durability is guaranteed unless [remove] is run inside an
      enclosing {!batch} operation, where durability will be guaranteed
      at the end of the batch. *)
+
+  val rename: t -> key -> key -> (unit, write_error) result Lwt.t
+  (** [rename t s d] rename [s] to [d] in [t].
+
+      If [d] exists, it is replaced by [s]. *)
 
   val batch: t -> ?retries:int -> (t -> 'a Lwt.t) -> 'a Lwt.t
   (** [batch t f] run [f] in batch. Ensure the durability of


### PR DESCRIPTION
This PR wants to add features to handle large values (several MB) by allowing to read and write at an offset, get the size of a value without needing to actually get the value, and rename a key without the need of get the old key + set the new key.

read and write must work on values, but size and rename can also handle directories. I purposely didn't specified what size should return for a directory (left to the implementation), and what rename should do for directories if the destination already exists (should mimic a fs?). For both, I'm not sure what actions are most relevant to perform.

/cc @hannesm @yomimono 