### PR TITLE
Mirage_kv.Key.add raises invalid_argument, docs

### DIFF
--- a/mirage-kv.opam
+++ b/mirage-kv.opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "optint" {>= "0.2.0"}
   "ptime" {>= "1.0.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "0.8.1"}
 ]
 synopsis: "MirageOS signatures for key/value devices"
 description: """

--- a/src/mirage_kv.ml
+++ b/src/mirage_kv.ml
@@ -22,7 +22,7 @@ module Key = struct
   (* Store the path as a reverse list to optimise basename and (/)
      operations *)
 
-  let err_invalid_segment x = Fmt.failwith "%S is not a valid segment" x
+  let err_invalid_segment x = Fmt.kstr invalid_arg "%S is not a valid segment" x
 
   let check_segment x =
     String.iter (function '/' -> err_invalid_segment x | _ -> ()) x;

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -43,11 +43,14 @@ module Key: sig
      equal. *)
 
   val add : t -> string -> t
-  (** [add t s] is the concatenated key [t/s]. Raise
-     [Invalid_argument] if [s] contains ["/"]. *)
+  (** [add t s] is the concatenated key [t/s].
+
+      @raise Invalid_argument if [s] contains ['/']. *)
 
   val ( / ) : t -> string -> t
-  (** [t / x] is [add t x]. *)
+  (** [t / x] is [add t x].
+
+      @raise Invalid_argument if [s] contains ['/']. *)
 
   val append : t -> t -> t
   (** [append x y] is the concatenated key [x/y]. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,7 +22,7 @@ let path_add () =
     try
       let _ = Key.(v p / b) in
       Alcotest.failf "%s is not a valid segment, should fail" b
-    with Failure _ -> ()
+    with Invalid_argument _ -> ()
   in
   check ""         "bar"  "/bar";
   check "/"        "foo"  "/foo";


### PR DESCRIPTION
The documentation says that Mirage_kv.Key.add raises `Invalid_argument`, but `Failure` was actually raised. This commit makes it raise `Invalid_argument`, and the doc string is improved by using `@raise`, and the behavior is documented for `Mirage_kv.Key.(/)` as well.