### PR TITLE
Loosen requirements of `digest`

### DIFF
--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -169,7 +169,7 @@ module type RO = sig
      [t].
 
       When the value bound to [k] is a dictionary, the implementation is
-      allowed to return [Error `Value_expected]. Otherwise, the digest is a
+      allowed to return [Error (`Value_expected _)]. Otherwise, the [digest] is a
       unique and deterministic digest of its entries. *)
 
   val size: t -> key -> (Optint.Int63.t, error) result Lwt.t

--- a/src/mirage_kv.mli
+++ b/src/mirage_kv.mli
@@ -168,8 +168,9 @@ module type RO = sig
   (** [digest t k] is the unique digest of the value bound to [k] in
      [t].
 
-      When the value bound to [k] is a dictionary, the digest is a
-     unique and deterministic digest of its entries. *)
+      When the value bound to [k] is a dictionary, the implementation is
+      allowed to return [Error `Value_expected]. Otherwise, the digest is a
+      unique and deterministic digest of its entries. *)
 
   val size: t -> key -> (Optint.Int63.t, error) result Lwt.t
   (** [size t k] is the size of [k] in [t]. *)


### PR DESCRIPTION
In many implementations it is not feasible to compute a recursive digest.

Motivated by https://github.com/mirage/ocaml-tar/issues/111